### PR TITLE
Removed space from join in line ~145

### DIFF
--- a/templates/etc/network/interfaces.j2
+++ b/templates/etc/network/interfaces.j2
@@ -142,7 +142,7 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
   {{ param['param'] }} {{ param['val'] }}
 {%         endfor %}
 {%       endif %}
-  bridge_ports {{ item['ports']|join(' ') }}
+  bridge_ports {{ item['ports']|join('') }}
 {%     endif %}
 
 {%   endfor %}


### PR DESCRIPTION
Hello, I ran into an issue on Ubuntu where the bridge_port line was getting a space between each character. Removing the space resolved the issue. If it helps:

Python 3.4.5
ansible 2.4.0.0

Python is being called in my ansible/hosts file like:

[host:vars]
ansible_python_interpreter=/usr/bin/python3

