### PR TITLE
Make configuration template configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # defaults file for ansible-config-interfaces
 
+config_interface_template: etc/network/interfaces.j2
+
 # Defines if network bonds should be configured as defined
 config_network_bonds: false
 

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -36,7 +36,7 @@
 
 - name: debian | Configuring Defined Interfaces
   template:
-    src: etc/network/interfaces.j2
+    src: "{{ config_interface_template }}"
     dest: /etc/network/interfaces
     owner: root
     group: root


### PR DESCRIPTION
This minor changes allows overriding the template used in the role to improve
integration with local requirements.