### PR TITLE
tasks/{debian,redhat}.yml: allow to not install lldp

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -200,3 +200,6 @@ ovs_interfaces:
   #   # parameters:
 
 pri_domain_name: example.org
+
+# Install or not lldp
+config_install_lldp: true

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -6,6 +6,7 @@
   become: true
   register: result
   until: result is successful
+  when: config_install_lldp | bool
 
 - name: debian | Installing bridge-utils
   apt:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -15,7 +15,9 @@
   become: true
   register: result
   until: result is successful
-  when: ansible_distribution != "Fedora"
+  when:
+  - config_install_lldp | bool
+  - ansible_distribution != "Fedora"
 
 - name: redhat | Installing bridge-utils
   yum:


### PR DESCRIPTION
In simple systems, this role is only needed to configure a fixed
IP or DHCP, so installing lldp on them is not so useful.
Add a new variable used to disable the lldp installation, and set
it to true by default, to not change the behaviour of the role.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>