### PR TITLE
Allow auto config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,9 @@
 
 config_interface_template: etc/network/interfaces.j2
 
+# Defines if auto should be configured as defined
+config_auto: false
+
 # Defines if network bonds should be configured as defined
 config_network_bonds: false
 

--- a/templates/etc/network/interfaces.j2
+++ b/templates/etc/network/interfaces.j2
@@ -12,7 +12,9 @@ iface lo inet loopback
 # {{ item['comment'] }}
 {%       endif %}
 {%       if item['method']|lower == "static" or item['method']|lower == "manual" %}
+{%         if item['auto'] is defined and item['auto'] %}
 auto {{ item['name'] }}
+{%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%         if item['address'] is defined and item['address'] != None %}
   address {{ item['address'] }}
@@ -25,7 +27,9 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%         endif %}
 {%       endif %}
 {%       if item['method']|lower == "dhcp" %}
+{%         if item['auto'] is defined and item['auto'] %}
 auto {{ item['name'] }}
+{%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%       endif %}
 {%       if item['wireless_network'] is defined and item['wireless_network'] %}
@@ -50,7 +54,9 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%       if item['comment'] is defined and item['comment'] != None %}
 # {{ item['comment'] }}
 {%       endif %}
+{%         if item['auto'] is defined and item['auto'] %}
 auto {{ item['name'] }}
+{%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%       if item['method']|lower == 'static' %}
 {%         if item['address'] is defined and item['address'] != None %}
@@ -85,7 +91,9 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
 # {{ item['comment'] }}
 {%       endif %}
 {%       if item['method']|lower == "static" or item['method']|lower == "manual" %}
+{%         if item['auto'] is defined and item['auto'] %}
 auto {{ item['name'] }}
+{%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%         if item['address'] is defined and item['address'] != None %}
   address {{ item['address'] }}
@@ -98,7 +106,9 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%         endif %}
 {%       endif %}
 {%       if item['method']|lower == "dhcp" %}
+{%         if item['auto'] is defined and item['auto'] %}
 auto {{ item['name'] }}
+{%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%       endif %}
 {%       if item['parameters'] is defined and item['parameters'] != None %}
@@ -121,7 +131,9 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
 # {{ item['comment'] }}
 {%       endif %}
 {%       if item['method']|lower == "static" or item['method']|lower == "manual" %}
+{%         if item['auto'] is defined and item['auto'] %}
 auto {{ item['name'] }}
+{%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%         if item['address'] is defined and item['address'] != None %}
   address {{ item['address'] }}
@@ -134,7 +146,9 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%         endif %}
 {%       endif %}
 {%       if item['method']|lower == "dhcp" %}
+{%         if item['auto'] is defined and item['auto'] %}
 auto {{ item['name'] }}
+{%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%       endif %}
 {%       if item['parameters'] is defined and item['parameters'] != None %}

--- a/templates/etc/network/interfaces.j2
+++ b/templates/etc/network/interfaces.j2
@@ -12,7 +12,11 @@ iface lo inet loopback
 # {{ item['comment'] }}
 {%       endif %}
 {%       if item['method']|lower == "static" or item['method']|lower == "manual" %}
-{%         if item['auto'] is defined and item['auto'] %}
+{%         if config_auto is defined and config_auto %}
+{%           if item['auto'] is defined and item['auto'] %}
+auto {{ item['name'] }}
+{%           endif %}
+{%         else %}
 auto {{ item['name'] }}
 {%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}
@@ -27,7 +31,11 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%         endif %}
 {%       endif %}
 {%       if item['method']|lower == "dhcp" %}
-{%         if item['auto'] is defined and item['auto'] %}
+{%         if config_auto is defined and config_auto %}
+{%           if item['auto'] is defined and item['auto'] %}
+auto {{ item['name'] }}
+{%           endif %}
+{%         else %}
 auto {{ item['name'] }}
 {%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}
@@ -54,7 +62,11 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%       if item['comment'] is defined and item['comment'] != None %}
 # {{ item['comment'] }}
 {%       endif %}
-{%         if item['auto'] is defined and item['auto'] %}
+{%         if config_auto is defined and config_auto %}
+{%           if item['auto'] is defined and item['auto'] %}
+auto {{ item['name'] }}
+{%           endif %}
+{%         else %}
 auto {{ item['name'] }}
 {%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}
@@ -91,7 +103,11 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
 # {{ item['comment'] }}
 {%       endif %}
 {%       if item['method']|lower == "static" or item['method']|lower == "manual" %}
-{%         if item['auto'] is defined and item['auto'] %}
+{%         if config_auto is defined and config_auto %}
+{%           if item['auto'] is defined and item['auto'] %}
+auto {{ item['name'] }}
+{%           endif %}
+{%         else %}
 auto {{ item['name'] }}
 {%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}
@@ -106,7 +122,11 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%         endif %}
 {%       endif %}
 {%       if item['method']|lower == "dhcp" %}
-{%         if item['auto'] is defined and item['auto'] %}
+{%         if config_auto is defined and config_auto %}
+{%           if item['auto'] is defined and item['auto'] %}
+auto {{ item['name'] }}
+{%           endif %}
+{%         else %}
 auto {{ item['name'] }}
 {%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}
@@ -131,7 +151,11 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
 # {{ item['comment'] }}
 {%       endif %}
 {%       if item['method']|lower == "static" or item['method']|lower == "manual" %}
-{%         if item['auto'] is defined and item['auto'] %}
+{%         if config_auto is defined and config_auto %}
+{%           if item['auto'] is defined and item['auto'] %}
+auto {{ item['name'] }}
+{%           endif %}
+{%         else %}
 auto {{ item['name'] }}
 {%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}
@@ -146,7 +170,11 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
 {%         endif %}
 {%       endif %}
 {%       if item['method']|lower == "dhcp" %}
-{%         if item['auto'] is defined and item['auto'] %}
+{%         if config_auto is defined and config_auto %}
+{%           if item['auto'] is defined and item['auto'] %}
+auto {{ item['name'] }}
+{%           endif %}
+{%         else %}
 auto {{ item['name'] }}
 {%         endif %}
 iface {{ item['name'] }} inet {{ item['method']|lower }}


### PR DESCRIPTION
Makes it so that `auto` is toggleable.

## Description
For a manual Proxmox configuration I needed to set an interface which didn't have auto.

## Related Issue
#29 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document. - **Can't find it**
- [ ] I have run the pre-merge tests locally and they pass. - **Can't find it**
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. **What type of test are required?**
- [x] All new and existing tests passed.
